### PR TITLE
Add toggle for box control button visibility

### DIFF
--- a/StswExpress/Controls/Colors/StswColorBox.xaml
+++ b/StswExpress/Controls/Colors/StswColorBox.xaml
@@ -68,7 +68,8 @@
                                 </se:StswTabControl>
                             </se:StswDropButton>
                             <!-- separator -->
-                            <se:StswSeparator DockPanel.Dock="Right"
+                            <se:StswSeparator x:Name="OPT_ButtonSeparator"
+                                              DockPanel.Dock="Right"
                                               BorderBrush="{Binding BorderBrush, ElementName=OPT_MainBorder}"
                                               BorderThickness="{TemplateBinding SeparatorThickness}"
                                               Orientation="Vertical"
@@ -113,6 +114,10 @@
                     </se:StswBorder>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_DropButton"/>
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonSeparator"/>
+                        </Trigger>
                         <Trigger Property="Text" Value="{x:Null}">
                             <Setter Property="Visibility" Value="Visible" TargetName="OPT_Placeholder"/>
                         </Trigger>

--- a/StswExpress/Controls/DateTime/StswDatePicker.xaml
+++ b/StswExpress/Controls/DateTime/StswDatePicker.xaml
@@ -62,7 +62,8 @@
                                                  se:StswControl.IsBorderless="True"/>
                             </se:StswDropButton>
                             <!-- separator -->
-                            <se:StswSeparator DockPanel.Dock="Right"
+                            <se:StswSeparator x:Name="OPT_ButtonSeparator"
+                                              DockPanel.Dock="Right"
                                               BorderBrush="{Binding BorderBrush, ElementName=OPT_MainBorder}"
                                               BorderThickness="{TemplateBinding SeparatorThickness}"
                                               Orientation="Vertical"
@@ -100,6 +101,10 @@
                     </se:StswBorder>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_DropButton"/>
+                        <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonSeparator"/>
+                        </Trigger>
                         <Trigger Property="Text" Value="{x:Null}">
                             <Setter Property="Visibility" Value="Visible" TargetName="OPT_Placeholder"/>
                         </Trigger>

--- a/StswExpress/Controls/DateTime/StswTimePicker.xaml
+++ b/StswExpress/Controls/DateTime/StswTimePicker.xaml
@@ -92,7 +92,8 @@
                                 </StackPanel>
                             </se:StswDropButton>
                             <!-- separator -->
-                            <se:StswSeparator DockPanel.Dock="Right"
+                            <se:StswSeparator x:Name="OPT_ButtonSeparator"
+                                              DockPanel.Dock="Right"
                                               BorderBrush="{Binding BorderBrush, ElementName=OPT_MainBorder}"
                                               BorderThickness="{TemplateBinding SeparatorThickness}"
                                               Orientation="Vertical"
@@ -130,6 +131,10 @@
                     </se:StswBorder>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_DropButton"/>
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonSeparator"/>
+                        </Trigger>
                         <Trigger Property="Text" Value="{x:Null}">
                             <Setter Property="Visibility" Value="Visible" TargetName="OPT_Placeholder"/>
                         </Trigger>

--- a/StswExpress/Controls/Input/StswNumberBox.xaml
+++ b/StswExpress/Controls/Input/StswNumberBox.xaml
@@ -44,7 +44,7 @@
                             <!-- icon section -->
                             <ContentPresenter ContentSource="Icon" Focusable="False" IsHitTestVisible="False"/>
                             <!-- buttons -->
-                            <UniformGrid DockPanel.Dock="Right" Columns="1" Width="24">
+                            <UniformGrid x:Name="OPT_ButtonHost" DockPanel.Dock="Right" Columns="1" Width="24">
                                 <se:StswRepeatButton x:Name="PART_ButtonUp" Focusable="False" Padding="0" se:StswControl.IsBorderless="True">
                                     <se:StswIcon Data="M2,17L12,7L22,17H2Z" Margin="-3" Scale="1"/>
                                 </se:StswRepeatButton>
@@ -53,7 +53,7 @@
                                 </se:StswRepeatButton>
                             </UniformGrid>
                             <!-- separator -->
-                            <se:StswSeparator DockPanel.Dock="Right"
+                            <se:StswSeparator x:Name="OPT_ButtonSeparator" DockPanel.Dock="Right"
                                               BorderBrush="{Binding BorderBrush, ElementName=OPT_MainBorder}"
                                               BorderThickness="{Binding SeparatorThickness, RelativeSource={RelativeSource TemplatedParent}}"
                                               Orientation="Vertical"
@@ -91,6 +91,10 @@
                     </se:StswBorder>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonHost"/>
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonSeparator"/>
+                        </Trigger>
                         <Trigger Property="Text" Value="{x:Null}">
                             <Setter Property="Visibility" Value="Visible" TargetName="OPT_Placeholder"/>
                         </Trigger>

--- a/StswExpress/Controls/Paths/StswPathPicker.xaml
+++ b/StswExpress/Controls/Paths/StswPathPicker.xaml
@@ -52,7 +52,8 @@
                                 <se:StswIcon Data="{x:Static se:StswIcons.FolderOpen}"/>
                             </se:StswButton>
                             <!-- separator -->
-                            <se:StswSeparator DockPanel.Dock="Right"
+                            <se:StswSeparator x:Name="OPT_ButtonSeparator"
+                                              DockPanel.Dock="Right"
                                               BorderBrush="{Binding BorderBrush, ElementName=OPT_MainBorder}"
                                               BorderThickness="{TemplateBinding SeparatorThickness}"
                                               Orientation="Vertical"
@@ -135,6 +136,10 @@
                     </se:StswBorder>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="PART_DialogButton"/>
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_ButtonSeparator"/>
+                        </Trigger>
                         <Trigger Property="FileSize" Value="{x:Null}">
                             <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_FileSize"/>
                             <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_IconSeparator"/>

--- a/StswExpress/Controls/Selectors/StswComboBox.xaml
+++ b/StswExpress/Controls/Selectors/StswComboBox.xaml
@@ -188,10 +188,20 @@
                     </Grid>
                     <!-- triggers -->
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AreButtonsVisible" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_DropArrow"/>
+                            <Setter Property="Visibility" Value="Collapsed" TargetName="OPT_Separator"/>
+                        </Trigger>
                         <Trigger Property="IsEditable" Value="False">
-                            <Setter Property="Visibility" Value="Hidden" TargetName="OPT_Separator"/>
                             <Setter Property="Visibility" Value="Visible" TargetName="OPT_Content"/>
                         </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEditable" Value="False"/>
+                                <Condition Property="AreButtonsVisible" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Hidden" TargetName="OPT_Separator"/>
+                        </MultiTrigger>
                         <Trigger Property="IsEditable" Value="True">
                             <Setter Property="IsTabStop" Value="False"/>
                             <Setter Property="Padding" Value="0" TargetName="OPT_MainButton"/>

--- a/StswExpress/Controls/Selectors/StswComboBox.xaml.cs
+++ b/StswExpress/Controls/Selectors/StswComboBox.xaml.cs
@@ -316,12 +316,28 @@ public class StswComboBox : ComboBox, IStswBoxControl, IStswCornerControl, IStsw
     }
 
     /// <inheritdoc/>
-    [StswInfo("0.1.0")]
-    public string? Placeholder
+    #region Style properties
+    /// <summary>
+    /// Gets or sets a value indicating whether the drop-down button area should be visible.
+    /// </summary>
+    public bool AreButtonsVisible
     {
-        get => (string?)GetValue(PlaceholderProperty);
-        set => SetValue(PlaceholderProperty, value);
+        get => (bool)GetValue(AreButtonsVisibleProperty);
+        set => SetValue(AreButtonsVisibleProperty, value);
     }
+    public static readonly DependencyProperty AreButtonsVisibleProperty
+        = DependencyProperty.Register(
+            nameof(AreButtonsVisible),
+            typeof(bool),
+            typeof(StswComboBox),
+            new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange)
+        );
+
+    /// <inheritdoc/>
+    public bool CornerClipping
+    {
+        get => (bool)GetValue(CornerClippingProperty);
+        set => SetValue(CornerClippingProperty, value);
     public static readonly DependencyProperty PlaceholderProperty
         = DependencyProperty.Register(
             nameof(Placeholder),

--- a/StswExpress/Controls/_base/StswBoxBase.cs
+++ b/StswExpress/Controls/_base/StswBoxBase.cs
@@ -190,5 +190,22 @@ public abstract class StswBoxBase : TextBox, IStswBoxControl, IStswCornerControl
             typeof(StswBoxBase),
             new FrameworkPropertyMetadata(default(double), FrameworkPropertyMetadataOptions.AffectsRender)
         );
+
+    /// <summary>
+    /// Gets or sets a value indicating whether action buttons inside the box should be visible.
+    /// This controls elements such as drop-down buttons or increment arrows displayed next to the text input.
+    /// </summary>
+    public bool AreButtonsVisible
+    {
+        get => (bool)GetValue(AreButtonsVisibleProperty);
+        set => SetValue(AreButtonsVisibleProperty, value);
+    }
+    public static readonly DependencyProperty AreButtonsVisibleProperty
+        = DependencyProperty.Register(
+            nameof(AreButtonsVisible),
+            typeof(bool),
+            typeof(StswBoxBase),
+            new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange)
+        );
     #endregion
 }


### PR DESCRIPTION
## Summary
- add a reusable AreButtonsVisible dependency property to `StswBoxBase` and `StswComboBox`
- hide drop buttons, arrow groups, and separators when button visibility is disabled across color, number, date, time, and path pickers
- allow `StswComboBox` templates to collapse the arrow and separator area when buttons are hidden

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da3ee297808327ba1923059a077923